### PR TITLE
redis-cli: Fix memory leak in myread function

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1627,6 +1627,7 @@ static int myread(FILE * fp, char ** buf, int * buf_size, int * p_reqcnt){
 
     if (!cmdSupport(msg)){
         NOTICE("cmd not support: %s", msg->argv[0]); //TODO
+        freeMsg(msg);
         return 0;
     }
 


### PR DESCRIPTION
There may be memory leak while (!cmdSupport(msg)) is true, need freeMsg for releasing memory.

Signed-off-by: mengshengzhi mengshengzhi@baidu.com
